### PR TITLE
Restrict access to specific views and update querysets

### DIFF
--- a/voluntariados-backend/apps/facultad/views.py
+++ b/voluntariados-backend/apps/facultad/views.py
@@ -1,19 +1,22 @@
 from rest_framework import viewsets, permissions
 from .models import Facultad, Carrera
 from .serializers import FacultadSerializer, CarreraSerializer
+from apps.users.permissions import IsAdministrador
 
 class FacultadViewSet(viewsets.ModelViewSet):
     """
-    CRUD de Facultades. Lectura pública, escritura autenticada (cambiar si hace falta).
+    ViewSet para gestionar Facultades.
+    Solo los administradores tienen permiso para acceder a estas vistas.
     """
-    queryset = Facultad.objects.prefetch_related("carreras").all()
+    queryset = Facultad.objects.all().order_by('nombre')
     serializer_class = FacultadSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [permissions.IsAuthenticated, IsAdministrador]
 
 class CarreraViewSet(viewsets.ModelViewSet):
     """
-    CRUD de Carreras. Al crear una carrera pasás `facultad` (PK) en el payload.
+    ViewSet para gestionar Carreras.
+    Solo los administradores tienen permiso para acceder a estas vistas.
     """
-    queryset = Carrera.objects.select_related("facultad").all()
+    queryset = Carrera.objects.all().order_by('nombre')
     serializer_class = CarreraSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [permissions.IsAuthenticated, IsAdministrador]

--- a/voluntariados-backend/apps/organizacion/views.py
+++ b/voluntariados-backend/apps/organizacion/views.py
@@ -1,14 +1,15 @@
 from rest_framework import viewsets, permissions
 from .models import Organizacion
 from .serializers import OrganizacionSerializer
+from apps.users.permissions import IsAdministrador
 
 class OrganizacionViewSet(viewsets.ModelViewSet):
     """
-    CRUD de Organizaciones.
-    Lectura: pública/autenticada según settings.
-    Escritura: solo usuarios autenticados (o restringir a admin/delegado).
+    ViewSet para gestionar Organizaciones.
+
+    Permite operaciones CRUD completas (Crear, Leer, Actualizar, Borrar).
+    Solo los administradores tienen permiso para acceder a estas vistas.
     """
-    queryset = Organizacion.objects.select_related("contacto_persona", "localidad").all()
+    queryset = Organizacion.objects.all().order_by('nombre')
     serializer_class = OrganizacionSerializer
-    # permission_classes = [permissions.IsAuthenticatedOrReadOnly]
-    
+    permission_classes = [permissions.IsAuthenticated, IsAdministrador]


### PR DESCRIPTION
Restrict access to Facultad, Carrera, and Organizacion views to administrators only. Additionally, update querysets for these views to be ordered by the `nombre` field.